### PR TITLE
Adaptation to ROS indigo (building as ros package).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,23 +3,23 @@ project(easydepthcalibration)
 
 find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs cv_bridge image_transport)
 
-SET(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "-O3")
+#SET(CMAKE_BUILD_TYPE Release)
+#set(CMAKE_CXX_FLAGS "-O3")
 
 FIND_PACKAGE(OpenCV REQUIRED)
 find_package(PCL)
 find_package(Boost)
 include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
-INCLUDE_DIRECTORIES(EIGEN3_INCLUDE_DIR /usr/include/eigen3 ${OpenCV_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}
+INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR} /usr/include/eigen3 ${OpenCV_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}
 ${PROJECT_SOURCE_DIR}/src/types/
-${PROJECT_SOURCE_DIR}/src/calibration/
-)
-#catkin_package()
+${PROJECT_SOURCE_DIR}/src/calibration/)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+catkin_package()
+
+#set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
+#set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
+#set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 
 include_directories( ${catkin_INCLUDE_DIRS} )
 
@@ -29,8 +29,7 @@ target_link_libraries(depthDumper_node ${catkin_LIBRARIES} ${OpenCV_LIBS} )
 
 #CALIBRATION UTILS
 add_library(calibration SHARED    src/calibration/calibration.h src/calibration/calibration.cpp
-                                  src/calibration/calibrationMatrix.h src/calibration/calibrationMatrix.cpp
-)
+                                  src/calibration/calibrationMatrix.h src/calibration/calibrationMatrix.cpp)
 target_link_libraries(calibration ${PCL_LIBRARIES} ${OpenCV_LIBS})
 
 
@@ -39,24 +38,20 @@ add_executable(driver_node src/driver/main.cpp)
 target_link_libraries(driver_node                   calibration
                                                     ${PCL_LIBRARIES}
                                                     ${OpenCV_LIBS}
-                                                    ${catkin_LIBRARIES}
-                                                    )
+                                                    ${catkin_LIBRARIES})
 
-add_executable(offlineCalibration	src/offlineCalibration/offlineCalibration.cpp
-)
+#Offline calibration
+add_executable(offlineCalibration	src/offlineCalibration/offlineCalibration.cpp)
 target_link_libraries(offlineCalibration types calibration ${PCL_LIBRARIES} ${OpenCV_LIBS})
 
-add_executable(batchCalibration	src/offlineCalibration/batchCalibration.cpp
-)
+#Batch calibration
+add_executable(batchCalibration	src/offlineCalibration/batchCalibration.cpp)
 target_link_libraries(batchCalibration types calibration ${PCL_LIBRARIES} ${OpenCV_LIBS})
-
-
 
 #TYPES SHARED LIBRARY
 add_library(types SHARED    
 src/types/planeCloud.h 		src/types/planeCloud.cpp
 src/types/pointCloud.h 		src/types/pointCloud.cpp
-src/types/laserData.h 		src/types/laserData.cpp
-)
+src/types/laserData.h 		src/types/laserData.cpp)
 
 target_link_libraries(types ${PCL_LIBRARIES} ${OpenCV_LIBS})

--- a/src/calibration/calibration.cpp
+++ b/src/calibration/calibration.cpp
@@ -9,7 +9,7 @@ void calibration::voxelize(pcl::PointCloud<pcl::PointXYZ>* inCloud,pcl::PointClo
     sor.filter (*outCloud);
     //std::cout<<" OUT has "<<outCloud->size()<<std::endl;
 }
-void calibration::computeCenterSquareCloud(cv::Mat& depthImage,Eigen::Matrix3f k, pcl::PointCloud<pcl::PointXYZ>* outCloud, int width, int height){
+void calibration::computeCenterSquareCloud(cv::Mat& depthImage,Eigen::Matrix3f k, pcl::PointCloud<pcl::PointXYZ>* outCloud, int width, int height, float c0, float c1, float c2, float c3){
     outCloud->clear();
     int cols=depthImage.cols;
     int rows=depthImage.rows;

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -9,7 +9,7 @@
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 #include <string>
-#include <boost/signal.hpp>
+#include <boost/signals2.hpp>
 #include <boost/bind.hpp>
 #include <opencv2/opencv.hpp>
 #include <image_transport/image_transport.h>


### PR DESCRIPTION
Hello!

I needed to use a clever depth calibration in my Xtion cameras and found your paper and repository. Compiling up-to-date version didn't not allow to use it as ros package. There is also some changes to get rid of all warnings during compilation.

How do you think? :smile: 

Regards,
Daniel